### PR TITLE
Accumulate api records

### DIFF
--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -552,7 +552,7 @@ class WeatherFlowUDPDriver(weewx.drivers.AbstractDevice):
         finally:
             sock.close()
 
-    def genStartupRecords(self, since_ts):            
+    def genStartupRecords(self, since_ts):
         if since_ts == None:
             since_ts = int(time.time()) - 365 * 24 * 60 * 60
             

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -574,7 +574,7 @@ class WeatherFlowUDPDriver(weewx.drivers.AbstractDevice):
                                 archivePeriod = ArchivePeriod(weeutil.weeutil.startOfInterval(m3['dateTime'], self._archive_interval), self._archive_interval, self._archive_delay)
                             
                             if m3['dateTime'] >= archivePeriod._end_archive_delay_ts:
-                                archivePeriod.startNextArchiveInterval()
+                                archivePeriod.startNextArchiveInterval(weeutil.weeutil.startOfInterval(m3['dateTime'], self._archive_interval))
                             
                             # Try adding the API packet to the existing accumulator. If the
                             # timestamp is outside the timespan of the accumulator, an exception
@@ -610,8 +610,8 @@ class ArchivePeriod:
         self._accumulator = weewx.accum.Accum(weeutil.weeutil.TimeSpan(self._start_archive_period_ts, self._end_archive_period_ts))
         self._old_accumulator = None
         
-    def startNextArchiveInterval(self):
-        self._start_archive_period_ts = self._end_archive_period_ts
+    def startNextArchiveInterval(self, start_archive_period_ts):
+        self._start_archive_period_ts = start_archive_period_ts
         self._end_archive_period_ts = self._start_archive_period_ts + self._archive_interval
         if (self._end_archive_period_ts > time.time()):
             self_end_archive_period_ts = int(time.time())

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -574,7 +574,7 @@ class WeatherFlowUDPDriver(weewx.drivers.AbstractDevice):
                                 start_archive_period_ts = weeutil.weeutil.startOfInterval(since_ts, self._archive_interval)
                                 end_archive_period_ts = start_archive_period_ts + self._archive_interval
                                 if (end_archive_period_ts > time.time()):
-                                    end_archive_period_ts = time.time()
+                                    end_archive_period_ts = int(time.time())
                                 end_archive_delay_ts = end_archive_period_ts + self._archive_delay
                                 accumulator = weewx.accum.Accum(weeutil.weeutil.TimeSpan(start_archive_period_ts, end_archive_period_ts))
                             
@@ -583,7 +583,7 @@ class WeatherFlowUDPDriver(weewx.drivers.AbstractDevice):
                                 start_archive_period_ts = end_archive_period_ts
                                 end_archive_period_ts = end_archive_period_ts + self._archive_interval
                                 if (end_archive_period_ts > time.time()):
-                                    end_archive_period_ts = time.time()
+                                    end_archive_period_ts = int(time.time())
                                 end_archive_delay_ts = end_archive_period_ts + self._archive_delay
                                 
                                 (old_accumulator, accumulator) = \

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -571,7 +571,7 @@ class WeatherFlowUDPDriver(weewx.drivers.AbstractDevice):
                             # Use an accumulator and treat REST API data like loop data
                             if not archivePeriod:
                                 # init archivePeriod
-                                archivePeriod = ArchivePeriod(weeutil.weeutil.startOfInterval(since_ts, self._archive_interval), self._archive_interval, self._archive_delay)
+                                archivePeriod = ArchivePeriod(weeutil.weeutil.startOfInterval(m3['dateTime'], self._archive_interval), self._archive_interval, self._archive_delay)
                             
                             if m3['dateTime'] >= archivePeriod._end_archive_delay_ts:
                                 archivePeriod.startNextArchiveInterval()

--- a/bin/user/weatherflowudp.py
+++ b/bin/user/weatherflowudp.py
@@ -591,10 +591,11 @@ class WeatherFlowUDPDriver(weewx.drivers.AbstractDevice):
                             if archive_record:
                                 logdbg('Archiving accumulated data from REST %s' % archivePeriod._start_archive_period_ts)
                                 yield archive_record
-            archive_record = archivePeriod.getRecord()
-            if archive_record:
-                # return record from last processed accumulator 
-                yield archive_record
+            if archivePeriod:
+                archive_record = archivePeriod.getRecord()
+                if archive_record:
+                    # return record from last processed accumulator 
+                    yield archive_record
         else:
             loginf('Skipped fetching from REST API')
 


### PR DESCRIPTION
I have added an accumulator to add the API records in the right archive interval to the database. This was mainly copy&past from the handling of the loop packets.

I have created a complete new database for my station and started the driver as test. Results are as desired.
I have not tested what happens when data is missing in the weatherflow cloud.